### PR TITLE
This fixes the crash caused by large factorials

### DIFF
--- a/jscl/src/main/java/jscl/math/operator/Factorial.java
+++ b/jscl/src/main/java/jscl/math/operator/Factorial.java
@@ -39,7 +39,7 @@ public class Factorial extends PostfixFunction {
             }
 
             Generic result = JsclInteger.valueOf(1);
-            for (int i = 0; i < n; i++) {
+            for (int i = 0; i < n && i < 200; i++) {
                 ParserUtils.checkInterruption();
                 result = result.multiply(JsclInteger.valueOf(i + 1));
             }


### PR DESCRIPTION
This stops the calculations of the factorial after 200,
because after 170! the BigInteger is too large for a Double anyways and
will be shown as positive infinity.

fixes #161 
